### PR TITLE
Add initializer block to engine that precompiles assets.

### DIFF
--- a/lib/epic-editor-rails/engine.rb
+++ b/lib/epic-editor-rails/engine.rb
@@ -2,6 +2,15 @@ module Epic
   module Editor
     module Rails
       class Engine < ::Rails::Engine
+        if ::Rails.version >= "3.1"
+          initializer "Precompile EpicEditor assets" do |app|
+            app.config.assets.precompile += [
+              "epiceditor.js", "base/epiceditor.css",
+              "editor/epic-dark.css", "editor/epic-light.css",
+              "preview/bartik.css", "preview/github.css", "preview-dark.css"
+            ]
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Without this, running in Production with `config.assets.compile = false` will not work.
