### PR TITLE
Remove instructions on @imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ application.js:
 //= require 'epiceditor'  
 ```
 
-specifying themes:
+specifying themes (eg, in a `.js.erb` file, or in a `<script>` tag):
 ```erb
 new EpicEditor({
   theme: {
@@ -17,6 +17,8 @@ new EpicEditor({
   }
 }).load();
 ```
+
+otherwise, follow all instructions and patterns from the upstream [EpicEditor](https://github.com/OscarGodson/EpicEditor) README
 
 EpicEditor v0.2.3  
 http://epiceditor.com/  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ application.js:
 //= require 'epiceditor'  
 ```
 
-specifying themes (eg, in a `.js.erb` file, or in a `<script>` tag):
+All instructions and patterns from the upstream's README ([EpicEditor](https://github.com/OscarGodson/EpicEditor)) can be applied directly.
+
+With the exception of specifying themes, which can be accomplished along the lines of:
 ```erb
 new EpicEditor({
   theme: {
@@ -17,8 +19,6 @@ new EpicEditor({
   }
 }).load();
 ```
-
-otherwise, follow all instructions and patterns from the upstream [EpicEditor](https://github.com/OscarGodson/EpicEditor) README
 
 EpicEditor v0.2.3  
 http://epiceditor.com/  

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ application.js:
 //= require 'epiceditor'  
 ```
 
-application.css.(scss):
-```
-@import 'base/epiceditor';  
-@import 'preview/bartik';  
-@import 'preview/github';  
-@import 'preview/preview-dark';  
-@import 'editor/epic-dark';  
-@import 'editor/epic-light';  
+specifying themes:
+```erb
+new EpicEditor({
+  theme: {
+    editor: '<%= asset_path 'editor/epic-light.css' %>',
+    preview: '<%= asset_path 'preview/preview-dark.css' %>'
+  }
+}).load();
 ```
 
 EpicEditor v0.2.3  


### PR DESCRIPTION
Doing those `@import`s in `application.css.scss` doesn't accomplish anything, beyond increasing the load time and size of the page through unused duplication.

[Theme styles are loaded dynamically by the JS](https://github.com/zethussuen/epic-editor-rails/blob/master/vendor/assets/javascripts/epiceditor.js.erb#L338).
